### PR TITLE
Adding individual configuration run detailed output

### DIFF
--- a/src/java/autoweka/ClassifierRunner.java
+++ b/src/java/autoweka/ClassifierRunner.java
@@ -320,13 +320,20 @@ public class ClassifierRunner
         	FileWriter writer = new FileWriter(mIndividualResultsFileName, true);
         	StringBuilder builder = new StringBuilder();
         	String delim = "\t";
+
+        	List<String> attributeEvalArgs = argMap.get("attributeeval");
+			String strAttributeEvalArgs = attributeEvalArgs != null ? Util.joinStrings(" ",  attributeEvalArgs) : "";
+			
+			List<String> attributeSearchArgs = argMap.get("attributesearch");
+			String strAttributeSearchArgs = attributeSearchArgs != null ? Util.joinStrings(" ",  attributeSearchArgs) : "";
+			
 			builder
 	        	.append(targetClassifierName).append(delim)
 	        	.append(Util.joinStrings(" ",  argsArraySaved)).append(delim)
 	        	.append(attribEvalClassName).append(delim)
-	        	.append(Util.joinStrings(" ",  argMap.getOrDefault("attributeeval", Collections.EMPTY_LIST))).append(delim)
+	        	.append(strAttributeEvalArgs).append(delim)
 	        	.append(attribSearchClassName).append(delim)
-	        	.append(Util.joinStrings(" ",  argMap.getOrDefault("attributesearch", Collections.EMPTY_LIST))).append(delim)
+	        	.append(strAttributeSearchArgs).append(delim)
 	        	.append(instanceStr).append(delim)
 	        	.append(res.getRawScore()).append(delim)
 	        	.append("\n");

--- a/src/java/autoweka/ClassifierRunner.java
+++ b/src/java/autoweka/ClassifierRunner.java
@@ -42,6 +42,7 @@ public class ClassifierRunner
     private boolean mDisableOutput = false;
     private java.io.PrintStream mSavedOutput = null;
     private String mPredictionsFileName = null;
+	private String mIndividualResultsFileName;
 
     /**
      * Prepares a runner with the specified properties.
@@ -58,6 +59,7 @@ public class ClassifierRunner
         mTestOnly = Boolean.valueOf(props.getProperty("onlyTest", "false"));
         mDisableOutput = Boolean.valueOf(props.getProperty("disableOutput", "false"));
         mPredictionsFileName = props.getProperty("predictionsFileName", null);
+        mIndividualResultsFileName = props.getProperty("individualResultsFile", "individual-results.tsv");
     }
 
     /**
@@ -313,6 +315,28 @@ public class ClassifierRunner
         attribEvalClassName, argMap.get("attributeeval"),
         attribSearchClassName, argMap.get("attributesearch"),
         instanceStr, res.getRawScore());
+        
+        try {
+        	FileWriter writer = new FileWriter(mIndividualResultsFileName, true);
+        	StringBuilder builder = new StringBuilder();
+        	String delim = "\t";
+			builder
+	        	.append(targetClassifierName).append(delim)
+	        	.append(Arrays.toString(argsArraySaved)).append(delim)
+	        	.append(attribEvalClassName).append(delim)
+	        	.append(argMap.get("attributeeval")).append(delim)
+	        	.append(attribSearchClassName).append(delim)
+	        	.append(argMap.get("attributesearch")).append(delim)
+	        	.append(instanceStr).append(delim)
+	        	.append(res.getRawScore()).append(delim)
+	        	.append("\n");
+        	writer.write(builder.toString());
+        	writer.flush();
+        	writer.close();
+        }
+        catch(IOException e) {
+        	log.error(e.toString());
+        }
 
         log.debug("Num Training: {}, num testing: {}", training.numInstances(), testing.numInstances());
         return res;

--- a/src/java/autoweka/ClassifierRunner.java
+++ b/src/java/autoweka/ClassifierRunner.java
@@ -17,7 +17,7 @@ import weka.attributeSelection.ASSearch;
 import weka.attributeSelection.AttributeSelection;
 import java.util.Map;
 import java.util.Arrays;
-
+import java.util.Collections;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -322,11 +322,11 @@ public class ClassifierRunner
         	String delim = "\t";
 			builder
 	        	.append(targetClassifierName).append(delim)
-	        	.append(Arrays.toString(argsArraySaved)).append(delim)
+	        	.append(Util.joinStrings(" ",  argsArraySaved)).append(delim)
 	        	.append(attribEvalClassName).append(delim)
-	        	.append(argMap.get("attributeeval")).append(delim)
+	        	.append(Util.joinStrings(" ",  argMap.getOrDefault("attributeeval", Collections.EMPTY_LIST))).append(delim)
 	        	.append(attribSearchClassName).append(delim)
-	        	.append(argMap.get("attributesearch")).append(delim)
+	        	.append(Util.joinStrings(" ",  argMap.getOrDefault("attributesearch", Collections.EMPTY_LIST))).append(delim)
 	        	.append(instanceStr).append(delim)
 	        	.append(res.getRawScore()).append(delim)
 	        	.append("\n");

--- a/src/java/autoweka/tools/ExperimentRunner.java
+++ b/src/java/autoweka/tools/ExperimentRunner.java
@@ -2,6 +2,7 @@ package autoweka.tools;
 
 import java.io.File;
 import java.net.URLDecoder;
+import java.util.Arrays;
 
 import autoweka.Experiment;
 import autoweka.TrajectoryParser;

--- a/src/java/weka/classifiers/meta/AutoWEKAClassifier.java
+++ b/src/java/weka/classifiers/meta/AutoWEKAClassifier.java
@@ -42,13 +42,14 @@ import weka.core.Utils;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.InputStreamReader;
 import java.io.Serializable;
 
 import java.nio.file.Files;
-
+import java.text.DecimalFormat;
 import java.net.URLDecoder;
-
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -101,6 +102,8 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
     static final int DEFAULT_MEM_LIMIT = 1024;
     /** Default */
     static final int DEFAULT_N_BEST = 1;
+    static final int DEFAULT_SHOW_DETAILED_RESULTS = 0;
+    
     /** Internal evaluation method. */
     static enum Resampling {
         CrossValidation,
@@ -179,6 +182,10 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
     protected Evaluation eval;
 
     private transient weka.gui.Logger wLog;
+
+	private int nDetailedResults;
+
+	private String detailedResultString;
 
     /**
      * Main method for testing this class.
@@ -367,6 +374,42 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
         log.info("classifier: {}, arguments: {}, attribute search: {}, attribute search arguments: {}, attribute evaluation: {}, attribute evaluation arguments: {}",
             classifierClass, classifierArgs, attributeSearchClass, attributeSearchArgs, attributeEvalClass, attributeEvalArgs);
 
+        if (nDetailedResults > 0) {
+        	String indvResultsFile = "individual-results.tsv"; // TODO
+        	BufferedReader reader = new BufferedReader(new FileReader(new File(msExperimentPath + expName, indvResultsFile)));
+
+        	Map<String, ConfigurationStats> totals = new HashMap<>(); 
+        	for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+        		String[] parts = line.split("\t");
+        		String id = parts[0] + ":" + parts[1] + ", ";
+        		id += parts[2] + ": " + parts[3] + ", ";
+        		id += parts[4] + ": " + parts[5];
+        		ConfigurationStats stats = totals.get(id);
+        		if (stats == null) {
+        			stats = new ConfigurationStats(id);
+        			totals.put(id, stats);
+        		}
+        		stats.addValue(Double.parseDouble(parts[7]));
+        	}
+        	StringBuilder builder = new StringBuilder();
+        	builder.append("======= Detailed Results ======").append("\n");
+        	List<ConfigurationStats> sorted = new ArrayList<>(totals.values());
+        	Collections.sort(sorted);
+        	int remaining = Math.min(nDetailedResults, sorted.size());
+        	for (ConfigurationStats stats : sorted) {
+        		// TODO: Ignore config stats that do not have enough data to be meaningful
+        		builder.append(stats.toString()).append("\n");
+        		remaining--;
+        		if (remaining == 0) {
+        			break;
+        		}
+        	}
+        	if (remaining > 0)
+        		builder.append(remaining + " other results truncated");
+        	builder.append("\n");
+        	detailedResultString = builder.toString();
+        	reader.close();
+        }
 
         //Print log of best configurations
         if (nBestConfigs>1){
@@ -446,6 +489,9 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
         result.addElement(
             new Option("\tThe amount of best configurations to return.\n" + "\t(default: " + DEFAULT_MEM_LIMIT + ")",
                 "nBestConfigs", 1, "-nBestConfigs <limit>"));
+        result.addElement(
+                new Option("\tThe number of detailed results that should be shown.\n" + "\t(default: " + DEFAULT_SHOW_DETAILED_RESULTS + ")",
+                    "nDetailedResults", 1, "-nDetailedResults <n>"));
         //result.addElement(
         //    new Option("\tThe type of resampling used.\n" + "\t(default: " + String.valueOf(DEFAULT_RESAMPLING) + ")",
         //        "resampling", 1, "-resampling <resampling>"));
@@ -527,6 +573,13 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
             nBestConfigs = Integer.parseInt(tmpStr);
         } else {
             nBestConfigs = DEFAULT_N_BEST;
+        }
+        
+        tmpStr = Utils.getOption("nDetailedResults", options);
+        if (tmpStr.length() != 0) {
+            nDetailedResults = Integer.parseInt(tmpStr);
+        } else {
+        	nDetailedResults = DEFAULT_SHOW_DETAILED_RESULTS;
         }
 
 
@@ -784,6 +837,12 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
             res += eval.toClassDetailsString();
         } catch(Exception e) { /*TODO treat*/ }
 
+          if (nDetailedResults > 0) {
+        	  res += "\n";
+        	  res += detailedResultString;
+        	  res += "\n";
+          }
+        
 		  if(nBestConfigs>1){
 			  
 			  ConfigurationCollection cc = ConfigurationCollection.fromXML(msExperimentPath+expName+"/"+configurationRankingPath,ConfigurationCollection.class);
@@ -835,5 +894,40 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
             throw new IllegalArgumentException(additionalMeasureName
                     + " not supported (Auto-WEKA)");
         }
+  }
+    
+  private static class ConfigurationStats implements Comparable<ConfigurationStats> {
+	private static final DecimalFormat df = new DecimalFormat("0.00");
+	int n;
+	double total;
+	String id;
+	  
+	public ConfigurationStats(String id) {
+		this.id = id;
+	}
+	
+	public void addValue(double value) {
+		total += value;
+		// TODO: might be useful to hold on to the individual values and/or compute additional summary stats
+		n++;
+	}
+	
+	public double getTotalRuns() {
+		return total;
+	}
+	
+	public double getAverageScore() {
+		return total / n;
+	}
+	
+	@Override
+	public int compareTo(ConfigurationStats o) {
+		return Double.compare(this.getAverageScore(), o.getAverageScore());
+	}
+	
+	@Override
+	public String toString() {
+		return  df.format(total/n) + " (" + df.format(total) + " / " + n + "): " + id;
+	}
   }
 }

--- a/src/java/weka/classifiers/meta/AutoWEKAClassifier.java
+++ b/src/java/weka/classifiers/meta/AutoWEKAClassifier.java
@@ -168,6 +168,8 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
     protected int memLimit = DEFAULT_MEM_LIMIT;
     /** The amout of best configurations to return as output*/
     protected int nBestConfigs = DEFAULT_N_BEST;
+    /** The number of detailed configurations to list in the output (SMAC score and options)*/
+    protected int nDetailedResults;
     /** The internal evaluation method. */
     protected Resampling resampling = DEFAULT_RESAMPLING;
     /** The arguments to the evaluation method. */
@@ -182,8 +184,6 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
     protected Evaluation eval;
 
     private transient weka.gui.Logger wLog;
-
-	private int nDetailedResults;
 
 	private String detailedResultString;
 
@@ -378,12 +378,13 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
         	String indvResultsFile = "individual-results.tsv"; // TODO
         	BufferedReader reader = new BufferedReader(new FileReader(new File(msExperimentPath + expName, indvResultsFile)));
 
-        	Map<String, ConfigurationStats> totals = new HashMap<>(); 
+        	Map<String, ConfigurationStats> totals = new HashMap<String, ConfigurationStats>(); 
         	for (String line = reader.readLine(); line != null; line = reader.readLine()) {
         		String[] parts = line.split("\t");
-        		String id = parts[0] + ":" + parts[1] + ", ";
-        		id += parts[2] + ": " + parts[3] + ", ";
-        		id += parts[4] + ": " + parts[5];
+        		String classifierName = parts[0];
+				String id = classifierName + " " + parts[1] + ", ";
+        		id += parts[2] + " " + parts[3] + ", ";
+        		id += parts[4] + " " + parts[5];
         		ConfigurationStats stats = totals.get(id);
         		if (stats == null) {
         			stats = new ConfigurationStats(id);
@@ -392,8 +393,8 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
         		stats.addValue(Double.parseDouble(parts[7]));
         	}
         	StringBuilder builder = new StringBuilder();
-        	builder.append("======= Detailed Results ======").append("\n");
-        	List<ConfigurationStats> sorted = new ArrayList<>(totals.values());
+        	builder.append("\n======= Detailed Results ======").append("\n\n");
+        	List<ConfigurationStats> sorted = new ArrayList<ConfigurationStats>(totals.values());
         	Collections.sort(sorted);
         	int remaining = Math.min(nDetailedResults, sorted.size());
         	for (ConfigurationStats stats : sorted) {
@@ -527,6 +528,8 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
         result.add("" + memLimit);
         result.add("-nBestConfigs");
         result.add("" + nBestConfigs);
+        result.add("-nDetailedResults");
+        result.add("" + nDetailedResults);
         //result.add("-resampling");
         //result.add("" + resampling);
         //result.add("-resamplingArgs");
@@ -697,6 +700,21 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
    }
 
    /**
+    * @return the number of detailed configs to show
+    */
+   public int getnDetailedResults() {
+	return nDetailedResults;
+   }
+   
+   /**
+    * Sets the number of detailed configs to show
+    * @param nDetailedResults the number of detailed configs to show
+ 	*/
+   public void setnDetailedResults(int nDetailedResults) {
+	this.nDetailedResults = nDetailedResults;
+   }
+
+   /**
     * Returns the tip text for this property.
     * @return tip text for this property
     */
@@ -704,7 +722,15 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
        return "How many of the best configurations should be returned as output";
    }
 
+   /**
+    * Returns the tip text for this property.
+    * @return tip text for this property
+    */
+   public String nDetailedResultsTipText() {
+       return "How many of the best individual runs should be show in the output";
+   }
 
+   
     //public void setResampling(Resampling r) {
     //    resampling = r;
     //    resamplingArgs = resamplingArgsMap.get(r);


### PR DESCRIPTION
This is just a quick POC for the additional details that I thought would be useful to (optionally) output to the user.  There are many other things that might be interesting to look at (group by classifier, by feature selection method, etc).  Another reason this might be useful is that it gives a better feel for how much of the space was covered.  Here's an example of the output:

```
...
======= Detailed Results ======
1.52 (9.09 / 6): weka.classifiers.functions.SimpleLogistic:[-W, 0, -A], null: [], NONE: []
2.27 (9.09 / 4): weka.classifiers.trees.J48:[-O, -B, -S, -M, 4, -C, 0.18749064322639875], weka.attributeSelection.CfsSubsetEval: [-L], weka.attributeSelection.GreedyStepwise: [-C, -B, -N, 98]
2.86 (20.00 / 7): weka.classifiers.functions.Logistic:[-R, 8.92512734844605E-5], null: [], NONE: []
2.91 (29.09 / 10): weka.classifiers.meta.Vote:[-R, AVG, -S, 1, -B, weka.classifiers.lazy.KStar -B 6 -M n], weka.attributeSelection.CfsSubsetEval: [-L], weka.attributeSelection.GreedyStepwise: [-C, -B, -R]
2.91 (29.09 / 10): weka.classifiers.lazy.LWL:[-A, weka.core.neighboursearch.LinearNNSearch, -W, weka.classifiers.lazy.IBk, --, -K, 1], null: [], NONE: []
2.91 (29.09 / 10): weka.classifiers.functions.Logistic:[-R, 0.0020589705876213438], weka.attributeSelection.CfsSubsetEval: [-M, -L], weka.attributeSelection.GreedyStepwise: [-C, -N, 53]
2.91 (29.09 / 10): weka.classifiers.lazy.LWL:[-K, 120, -A, weka.core.neighboursearch.LinearNNSearch, -W, weka.classifiers.functions.SMO, --, -C, 0.865139219625099, -N, 0, -M, -K, weka.classifiers.functions.supportVector.Puk -S 9.31797731197373 -O 0.3068500462454044], weka.attributeSelection.CfsSubsetEval: [-M, -L], weka.attributeSelection.BestFirst: [-D, 2, -N, 6]
2.91 (29.09 / 10): weka.classifiers.bayes.NaiveBayes:[-K], weka.attributeSelection.CfsSubsetEval: [-M], weka.attributeSelection.GreedyStepwise: [-C, -N, 15]
2.91 (29.09 / 10): weka.classifiers.lazy.KStar:[-B, 68, -M, n], weka.attributeSelection.CfsSubsetEval: [], weka.attributeSelection.BestFirst: [-D, 1, -N, 4]
2.91 (29.09 / 10): weka.classifiers.bayes.NaiveBayes:[-K], weka.attributeSelection.CfsSubsetEval: [-M, -L], weka.attributeSelection.GreedyStepwise: [-C, -N, 382]
3.03 (9.09 / 3): weka.classifiers.rules.DecisionTable:[-E, acc, -S, weka.attributeSelection.BestFirst, -X, 1], weka.attributeSelection.CfsSubsetEval: [-L], weka.attributeSelection.GreedyStepwise: [-B, -N, 125]
3.03 (9.09 / 3): weka.classifiers.meta.RandomSubSpace:[-I, 52, -P, 0.3957305480960892, -S, 1, -W, weka.classifiers.rules.OneR, --, -B, 1], null: [], NONE: []
3.90 (27.27 / 7): weka.classifiers.meta.AdaBoostM1:[-P, 89, -I, 24, -S, 1, -W, weka.classifiers.rules.PART, --, -M, 25], null: [], NONE: []
3.91 (39.09 / 10): weka.classifiers.functions.MultilayerPerceptron:[-L, 0.3813523419289583, -M, 0.8870112088084634, -B, -H, t, -S, 1], weka.attributeSelection.CfsSubsetEval: [-M], weka.attributeSelection.GreedyStepwise: [-C, -B, -R]
4.03 (28.18 / 7): weka.classifiers.trees.RandomForest:[-I, 6, -K, 3, -depth, 0], null: [], NONE: []
4.16 (29.09 / 7): weka.classifiers.functions.Logistic:[-R, 4.2207013384891565E-4], null: [], NONE: []
4.82 (48.18 / 10): weka.classifiers.functions.Logistic:[-R, 2.448575719895999E-8], weka.attributeSelection.CfsSubsetEval: [], weka.attributeSelection.GreedyStepwise: [-C, -R]
4.91 (49.09 / 10): weka.classifiers.meta.AdaBoostM1:[-P, 100, -I, 2, -S, 1, -W, weka.classifiers.functions.Logistic, --, -R, 2.628587683174939E-4], null: [], NONE: []
// I've truncated the list for the pull-request

------- 5 BEST CONFIGURATIONS -------

These are the 5 best configurations, as ranked by SMAC
Please note that this list only contains configurations evaluated on every fold.
If you need more configurations, consider running Auto-WEKA for a longer time.

Configuration #1:
SMAC Score: 2.909090909090909
Argument String:
-_0__wekaclassifierslazylwl_00_K_HIDDEN 1 -_0__wekaclassifierslazylwl_02_U_HIDDEN 1 -_0__wekaclassifierslazylwl_04_A weka.core.neighboursearch.LinearNNSearch -_1_W weka.classifiers.lazy.IBk -_1_W_0_DASHDASH REMOVED -_1_W_1__wekaclassifierslazyibk_00_E REMOVE_PREV -_1_W_1__wekaclassifierslazyibk_01_INT_K 1 -_1_W_1__wekaclassifierslazyibk_02_X REMOVE_PREV -_1_W_1__wekaclassifierslazyibk_03_F REMOVE_PREV -_1_W_1__wekaclassifierslazyibk_04_I REMOVE_PREV -attributesearch NONE -attributetime 10.0 -targetclass weka.classifiers.lazy.LWL 

Configuration #2:
SMAC Score: 2.909090909090909
Argument String:
-_0__wekaclassifierslazylwl_00_K_HIDDEN 1 -_0__wekaclassifierslazylwl_01_1_K 120 -_0__wekaclassifierslazylwl_02_U_HIDDEN 0 -_0__wekaclassifierslazylwl_04_A weka.core.neighboursearch.LinearNNSearch -_1_W weka.classifiers.functions.SMO -_1_W_0_DASHDASH REMOVED -_1_W_1__wekaclassifiersfunctionssmo_00_0_C 0.865139219625099 -_1_W_1__wekaclassifiersfunctionssmo_01_1_N 0 -_1_W_1__wekaclassifiersfunctionssmo_02_2_M REMOVED -_1_W_1__wekaclassifiersfunctionssmo_03_3_REG_IGNORE_QUOTE_START_K weka.classifiers.functions.supportVector.Puk -_1_W_1__wekaclassifiersfunctionssmo_08_4_puk_S 9.31797731197373 -_1_W_1__wekaclassifiersfunctionssmo_09_4_puk_O 0.3068500462454044 -_1_W_1__wekaclassifiersfunctionssmo_11_5_QUOTE_END REMOVED -aseval__wekaattributeselectioncfssubseteval_00_0_M REMOVED -aseval__wekaattributeselectioncfssubseteval_01_1_L REMOVED -assearch__wekaattributeselectionbestfirst_00_0_D 2 -assearch__wekaattributeselectionbestfirst_01_1_INT_N 6 -attributeeval weka.attributeSelection.CfsSubsetEval -attributesearch weka.attributeSelection.BestFirst -attributetime 10.0 -targetclass weka.classifiers.lazy.LWL 

```
