### PR TITLE
Bugfix for the case in which no folds were evaluated

### DIFF
--- a/src/java/autoweka/Configuration.java
+++ b/src/java/autoweka/Configuration.java
@@ -23,9 +23,6 @@ import javax.xml.bind.annotation.*;
 @XmlRootElement(name="configuration")
 public class Configuration extends XmlSerializable implements Comparable{
 
-	//@TODO Use Doubles and Integers for scores and folds
-	//@TODO make this have a Metric attribute and use it to be more generic
-	//@TODO perhaps define > and < in terms of the score
 
 	@XmlElement(name="argStrings")
 	private String mArgStrings;
@@ -197,7 +194,10 @@ public class Configuration extends XmlSerializable implements Comparable{
 	}
 	
 
-	//@TODO I think im not longer using those, check this later.
+	public int getEvaluationAmount(){
+		return this.mScores.size();
+	}
+
 	public double getEvaluatedScore() { return mEvaluatedScore;}
 	public int getEvaluatedFold()     { return mEvaluatedFold;}
 	public int getAmtFolds()          { return mAmtFolds;}

--- a/src/java/autoweka/ConfigurationRanker.java
+++ b/src/java/autoweka/ConfigurationRanker.java
@@ -2,25 +2,19 @@ package autoweka;
 
 import java.io.File;
 
-import java.util.Arrays;
-import java.util.Scanner;
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
+//import java.io.FileNotFoundException;
+import java.io.FileNotFoundException;
+import java.util.*;
 
 import static weka.classifiers.meta.AutoWEKAClassifier.configurationRankingPath;
 import static weka.classifiers.meta.AutoWEKAClassifier.configurationInfoDirPath;
 import static weka.classifiers.meta.AutoWEKAClassifier.configurationHashSetPath;
 
 public class ConfigurationRanker{
-	//@TODO maybe integrate this class to ConfigurationCollection
 
 	//Loads configurations from temporary log, merges identical while merging the folds in which they were analyzed, sorts them and spits n of them to a xml
 
-	public static void rank(int n, String temporaryDirPath, String smacBest){
+	public static void rank(int n, String temporaryDirPath, String smacBest) throws FileNotFoundException, NoSuchElementException{
 
 		//Declaring some basic stuff
 		String hsPath = temporaryDirPath+configurationHashSetPath;
@@ -33,13 +27,12 @@ public class ConfigurationRanker{
 		Set<String> configHashes;
 
 		//Reading the hashes and removing duplicates
-		try{
-			redundantConfigHashes = (new Scanner(hashSetFile)).nextLine().split(",");
-			configHashes = new HashSet<String>(Arrays.asList(redundantConfigHashes));
-		}catch(Exception e){
-			System.out.println("Couldn't find config hash list file");
-			return;
-		}
+
+		redundantConfigHashes = (new Scanner(hashSetFile)).nextLine().split(",");
+		configHashes = new HashSet<String>(Arrays.asList(redundantConfigHashes));
+
+//
+
 		for(String hash : configHashes){
 			configs.add(Configuration.fromXML(cdPath+hash+".xml",Configuration.class));
 		}
@@ -49,7 +42,7 @@ public class ConfigurationRanker{
 			c.forceUpdateAverage();
 		}
 		Collections.sort(configs);
-		Collections.reverse(configs); //TODO invert definition in compareto rather than using this?
+		Collections.reverse(configs);
 
 		//Forcing the last incumbent to be the best configuration, in case of a tie
 		if (!smacBest.equals("IGNORE")){

--- a/src/java/autoweka/ConfigurationRanker.java
+++ b/src/java/autoweka/ConfigurationRanker.java
@@ -2,6 +2,8 @@ package autoweka;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+
+import java.util.NoSuchElementException;
 import java.util.Arrays;
 import java.util.Scanner;
 import java.util.ArrayList;

--- a/src/java/autoweka/ConfigurationRanker.java
+++ b/src/java/autoweka/ConfigurationRanker.java
@@ -2,7 +2,13 @@ package autoweka;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Scanner;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Collections;
+import java.util.List;
 
 import static weka.classifiers.meta.AutoWEKAClassifier.configurationRankingPath;
 import static weka.classifiers.meta.AutoWEKAClassifier.configurationInfoDirPath;

--- a/src/java/autoweka/ConfigurationRanker.java
+++ b/src/java/autoweka/ConfigurationRanker.java
@@ -1,8 +1,6 @@
 package autoweka;
 
 import java.io.File;
-
-//import java.io.FileNotFoundException;
 import java.io.FileNotFoundException;
 import java.util.*;
 

--- a/src/java/weka/classifiers/meta/AutoWEKAClassifier.java
+++ b/src/java/weka/classifiers/meta/AutoWEKAClassifier.java
@@ -419,7 +419,6 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
                     }
                 } });
             workers[i].start();
-            workers[i].start();
         }
         try {
             for(int i = 0; i < parallelRuns; i++) {

--- a/src/java/weka/classifiers/meta/AutoWEKAClassifier.java
+++ b/src/java/weka/classifiers/meta/AutoWEKAClassifier.java
@@ -46,6 +46,7 @@ import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.io.FileNotFoundException;
 
+
 import java.nio.file.Files;
 
 import java.net.URLDecoder;
@@ -63,6 +64,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.Vector;
+import java.util.NoSuchElementException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/java/weka/classifiers/meta/AutoWEKAClassifier.java
+++ b/src/java/weka/classifiers/meta/AutoWEKAClassifier.java
@@ -40,15 +40,29 @@ import weka.core.TechnicalInformation;
 import weka.core.TechnicalInformationHandler;
 import weka.core.Utils;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.io.Serializable;
+import java.io.FileNotFoundException;
 
 import java.nio.file.Files;
 
 import java.net.URLDecoder;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Observable;
+import java.util.Observer;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.Vector;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -404,6 +418,7 @@ public class AutoWEKAClassifier extends AbstractClassifier implements Additional
                         log.error(e.getMessage(), e);
                     }
                 } });
+            workers[i].start();
             workers[i].start();
         }
         try {

--- a/test/java/autoweka/ConfigurationTester.java
+++ b/test/java/autoweka/ConfigurationTester.java
@@ -1,12 +1,8 @@
 package autoweka;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Properties;
-
-import java.util.Random;
+import java.io.FileNotFoundException;
+import java.util.*;
 
 import org.junit.Test;
 import org.junit.Ignore;
@@ -143,8 +139,14 @@ public class ConfigurationTester{
       System.out.println("Couldn't initialize rankFilename.xml");
     }
 
+    try{
+      ConfigurationRanker.rank(1000,"test/experiment_folder/Auto-WEKA","IGNORE");
+    }catch(FileNotFoundException e){
+      System.out.println("caught a FileNotFoundException!");
+    }catch(NoSuchElementException e){
+      System.out.println("caught a NoSuchElementException!");
+    }
 
-    ConfigurationRanker.rank(1000,"test/experiment_folder/Auto-WEKA","IGNORE");
 
     ConfigurationCollection cc = ConfigurationCollection.fromXML(rankFilename, ConfigurationCollection.class);
     double bestScore = cc.get(0).getAverageScore();


### PR DESCRIPTION
In some cases, the dataset is so large or the time constraints are so short that, by the time Auto-WEKA finished the run, no folds are fully evaluated yet - and as a consequence some logs are not initialized.

This PR includes an error-check for this case.