### PR TITLE
Fix runtime error when running with WEKA-3.8.5

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -41,6 +41,7 @@
         <copy todir="${class.dir}">
             <fileset dir="src/java" includes="**/*.yml"/>
             <fileset dir="src/java" includes="**/*.png"/>
+            <fileset dir="src/java" includes="**/*.properties"/>
         </copy>
     </target>
     

--- a/src/java/autoweka/jaxb.properties
+++ b/src/java/autoweka/jaxb.properties
@@ -1,2 +1,3 @@
 javax.xml.bind.JAXBContextFactory=com.sun.xml.bind.v2.JAXBContextFactory
 javax.xml.bind.JAXBContext=com.sun.xml.bind.v2.ContextFactory
+javax.xml.bind.context.factory=com.sun.xml.bind.v2.ContextFactory

--- a/src/java/autoweka/jaxb.properties
+++ b/src/java/autoweka/jaxb.properties
@@ -1,0 +1,2 @@
+javax.xml.bind.JAXBContextFactory=com.sun.xml.bind.v2.JAXBContextFactory
+javax.xml.bind.JAXBContext=com.sun.xml.bind.v2.ContextFactory


### PR DESCRIPTION
Hi,

I have fixed the error about "Error marshalling XML response" when running Auto-WEKA with WEKA-3.8.5. The problem is that java11 has removed JAXB module which is used by Auto-WEKA.

I find that WEKA-3.8.5 has already included the necessary packages (jakarta.bine-api:2.3.3 and jaxb-runtime:2.3.3 etc.) but Auto-WEKA do not have the binding information of the implementation classes at runtime. A simple solution is to add the binding information (in jaxb.properties) with the class XmlSerializable.

Could you please consider merging this PR and release a new version.

Thank you,
Justin Liu