### PR TITLE
Fix NullPointerException error when launching WEKA with relative path…

### DIFF
--- a/src/java/autoweka/Util.java
+++ b/src/java/autoweka/Util.java
@@ -189,7 +189,7 @@ public class Util
 
     static public String getAbsoluteClasspath()
     {
-        return System.getProperty("java.class.path") + java.io.File.pathSeparatorChar + URLDecoder.decode(Util.class.getProtectionDomain().getCodeSource().getLocation().getPath());
+        return System.getProperty("java.class.path") + File.pathSeparatorChar + URLDecoder.decode(Attribute.class.getProtectionDomain().getCodeSource().getLocation().getPath()) + java.io.File.pathSeparatorChar + URLDecoder.decode(Util.class.getProtectionDomain().getCodeSource().getLocation().getPath());
     }
 
     /**


### PR DESCRIPTION
… of weka.jar

When launching weka with command such as "java -jar weka.jar", AutoWeka will raise NullPointerException because it cannot find weka.jar.

The problem is that the function getAbsoluteClasspath in Util simply return "java.class.path" property (so the value could be a relative path as we give when launching WEKA). When the value of path is used to run AutoWeka tasks, they will not be able to find weka.jar due to the work directory of those tasks is in the other location (usually in /tmp/autowekaxxxxxxxxxx). I think it is also related to the removed dedicated weka.jar from AutoWeka in the release 2.6.3.